### PR TITLE
Fix Findsodium.cmake version test.

### DIFF
--- a/cmake/Findsodium.cmake
+++ b/cmake/Findsodium.cmake
@@ -213,12 +213,12 @@ endif()
 
 # extract sodium version
 if (sodium_INCLUDE_DIR)
-    set(_VERSION_HEADER "${_INCLUDE_DIR}/sodium/version.h")
-    if (EXISTS _VERSION_HEADER)
+    set(_VERSION_HEADER "${sodium_INCLUDE_DIR}/sodium/version.h")
+    if (EXISTS "${_VERSION_HEADER}")
         file(READ "${_VERSION_HEADER}" _VERSION_HEADER_CONTENT)
         string(REGEX REPLACE ".*#[ \t]*define[ \t]*SODIUM_VERSION_STRING[ \t]*\"([^\n]*)\".*" "\\1"
             sodium_VERSION "${_VERSION_HEADER_CONTENT}")
-        set(sodium_VERSION "${sodium_VERSION}" PARENT_SCOPE)
+        set(sodium_VERSION "${sodium_VERSION}")
     endif()
 endif()
 


### PR DESCRIPTION
First change renames `${sodium_INCLUDE_DIR}`. Without that it will test for the existence of `/sodium/version.h` and not enter the branch.

Second change is `if (EXISTS "${_VERSION_HEADER}")` which otherwise will not enter the branch.

Third change `set(sodium_VERSION "${sodium_VERSION}" PARENT_SCOPE)` prevents a developer warning that `PARENT_SCOPE` does not exist.

Result: cmake outputs the following line which it did not before:
> -- Found sodium: /usr/lib/x86_64-linux-gnu/libsodium.so (found suitable version "1.0.16", minimum required is "1.0.14")