### PR TITLE
Workaround synapse bug #4898

### DIFF
--- a/lib/structs/responses/sync.cpp
+++ b/lib/structs/responses/sync.cpp
@@ -68,8 +68,17 @@ from_json(const json &obj, Ephemeral &ephemeral)
                                 auto event_id = it.key();
                                 auto users    = it.value().at("m.read");
 
-                                for (auto uit = users.begin(); uit != users.end(); ++uit)
-                                        user_times.emplace(uit.key(), uit.value().at("ts"));
+                                for (auto uit = users.begin(); uit != users.end(); ++uit) {
+					uint64_t ts = 0;
+                                        try {
+                                                ts = uit.value().at("ts");
+                                        } catch (json::type_error &) {
+                                                std::cerr
+                                                  << "mtxclient: Workaround synapse bug #4898, "
+                                                     "ignoring timestamp for m.receipt event\n";
+                                        }
+					user_times.emplace(uit.key(), ts);
+                                }
 
                                 receipts.emplace(event_id, user_times);
                         }


### PR DESCRIPTION
When synapse is using workers, it sends read receipts with data as a string not an object (see bug https://github.com/matrix-org/synapse/issues/4898). This causes the initial sync to loop, because it can't parse the response. This change works around this issue by ignoring those timestamps.

I also added a diagnostic message, but I couldn't figure out how to properly log errors (only found comments about log this, when there is proper logging), so I just wrote the message to stderr.

This should fix at least one case of https://github.com/Nheko-Reborn/nheko/issues/19, although it would probably also need proper error handling in initialSync in the long run (i.e. not retry infinitely on parse errors).