### PR TITLE
Build Shared Object

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ set_package_properties(nlohmann_json PROPERTIES
     TYPE REQUIRED
 )
 
+set(BUILD_SHARED_LIBS ON)
 set(Boost_USE_STATIC_LIBS OFF)
 set(Boost_USE_STATIC_RUNTIME OFF)
 set(Boost_USE_MULTITHREADED ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ set_package_properties(Boost PROPERTIES
     TYPE REQUIRED
 )
 
-add_library(matrix_client
+add_library(matrix_client SHARED
             lib/http/client.cpp
             lib/http/session.cpp
             lib/crypto/client.cpp

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -40,9 +40,9 @@ if(USE_BUNDLED_BOOST)
 endif()
 
 set(BOOST_URL
-    https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.bz2)
+    https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.bz2)
 set(BOOST_SHA256
-    7f6130bc3cf65f56a618888ce9d5ea704fa10b462be126ad053e80e553d6d8b7)
+    8f32d4617390d1c2d16f26a27ab60d97807b35440d45891fa340fc2648b04406)
 
 set(GTEST_URL https://github.com/google/googletest/archive/release-1.8.0.tar.gz)
 set(GTEST_SHA1 e7e646a6204638fe8e87e165292b8dd9cd4c36ed)

--- a/deps/cmake/Boost.cmake
+++ b/deps/cmake/Boost.cmake
@@ -16,7 +16,7 @@ ExternalProject_Add(
   CONFIGURE_COMMAND ${DEPS_BUILD_DIR}/boost/bootstrap.sh
     --with-libraries=random,thread,system,iostreams,atomic,chrono,date_time,regex
     --prefix=${DEPS_INSTALL_DIR}
-  BUILD_COMMAND ${DEPS_BUILD_DIR}/boost/b2 -d0 cxxstd=14 variant=release link=static threading=multi --layout=system
+  BUILD_COMMAND ${DEPS_BUILD_DIR}/boost/b2 -d0 cxxstd=14 variant=release link=shared runtime-link=shared threading=multi --layout=system
   INSTALL_COMMAND ${DEPS_BUILD_DIR}/boost/b2 -d0 install
 )
 


### PR DESCRIPTION
Build mtxclient as a shared object.  No longer statically link boost libs during build.