### PR TITLE
Basic support for room upgrade handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,7 @@ add_library(matrix_client
             lib/structs/events/power_levels.cpp
             lib/structs/events/redaction.cpp
             lib/structs/events/tag.cpp
+            lib/structs/events/tombstone.cpp
             lib/structs/events/topic.cpp
             lib/structs/events/messages/audio.cpp
             lib/structs/events/messages/emote.cpp

--- a/include/mtx/events.hpp
+++ b/include/mtx/events.hpp
@@ -48,6 +48,8 @@ enum class EventType
         RoomRedaction,
         /// m.room.pinned_events
         RoomPinnedEvents,
+        /// m.room.tombstone
+        RoomTombstone,
         // m.sticker
         Sticker,
         // m.tag
@@ -135,6 +137,9 @@ to_json(json &obj, const Event<Content> &event)
                 break;
         case EventType::RoomPinnedEvents:
                 obj["type"] = "m.room.pinned_events";
+                break;
+        case EventType::RoomTombstone:
+                obj["type"] = "m.room.tombstone";
                 break;
         case EventType::Sticker:
                 obj["type"] = "m.sticker";

--- a/include/mtx/events/collections.hpp
+++ b/include/mtx/events/collections.hpp
@@ -18,6 +18,7 @@
 #include "mtx/events/power_levels.hpp"
 #include "mtx/events/redaction.hpp"
 #include "mtx/events/tag.hpp"
+#include "mtx/events/tombstone.hpp"
 #include "mtx/events/topic.hpp"
 
 #include "mtx/events/messages/audio.hpp"
@@ -54,6 +55,7 @@ using StateEvents = boost::variant<events::StateEvent<states::Aliases>,
                                    events::StateEvent<states::Name>,
                                    events::StateEvent<states::PinnedEvents>,
                                    events::StateEvent<states::PowerLevels>,
+                                   events::StateEvent<states::Tombstone>,
                                    events::StateEvent<states::Topic>,
                                    events::StateEvent<msgs::Redacted>>;
 
@@ -69,6 +71,7 @@ using StrippedEvents = boost::variant<events::StrippedEvent<states::Aliases>,
                                       events::StrippedEvent<states::Name>,
                                       events::StrippedEvent<states::PinnedEvents>,
                                       events::StrippedEvent<states::PowerLevels>,
+                                      events::StrippedEvent<states::Tombstone>,
                                       events::StrippedEvent<states::Topic>>;
 
 //! Collection of @p StateEvent and @p RoomEvent. Those events would be
@@ -85,6 +88,7 @@ using TimelineEvents = boost::variant<events::StateEvent<states::Aliases>,
                                       events::StateEvent<states::Name>,
                                       events::StateEvent<states::PinnedEvents>,
                                       events::StateEvent<states::PowerLevels>,
+                                      events::StateEvent<states::Tombstone>,
                                       events::StateEvent<states::Topic>,
                                       events::EncryptedEvent<msgs::Encrypted>,
                                       events::RedactionEvent<msgs::Redaction>,
@@ -162,6 +166,10 @@ from_json(const json &obj, TimelineEvent &e)
         }
         case events::EventType::RoomRedaction: {
                 e.data = events::RedactionEvent<mtx::events::msg::Redaction>(obj);
+                break;
+        }
+        case events::EventType::RoomTombstone: {
+                e.data = events::StateEvent<Tombstone>(obj);
                 break;
         }
         case events::EventType::RoomTopic: {

--- a/include/mtx/events/create.hpp
+++ b/include/mtx/events/create.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <boost/optional.hpp>
 #include <nlohmann/json.hpp>
 
 using json = nlohmann::json;
@@ -7,6 +8,14 @@ using json = nlohmann::json;
 namespace mtx {
 namespace events {
 namespace state {
+
+struct PreviousRoom
+{
+        //! Required. The ID of the old room.
+        std::string room_id;
+        //! Required. The event ID of the last known event in the old room.
+        std::string event_id;
+};
 
 //! Content of the `m.room.create` event.
 //
@@ -16,9 +25,16 @@ struct Create
 {
         //! The `user_id` of the room creator. This is set by the homeserver.
         std::string creator;
+
         //! Whether users on other servers can join this room.
         //! Defaults to **true** if key does not exist.
         bool federate = true;
+
+        //! The version of the room. Defaults to "1" if the key does not exist.
+        std::string room_version = "1";
+
+        //! A reference to the room this room replaces, if the previous room was upgraded.
+        boost::optional<PreviousRoom> predecessor;
 };
 
 void

--- a/include/mtx/events/tombstone.hpp
+++ b/include/mtx/events/tombstone.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
+
+namespace mtx {
+namespace events {
+namespace state {
+
+//! Content for the `m.room.tombstone` event.
+//
+//! A state event signifying that a room has been
+//! upgraded to a different room version, and
+//! that clients should go there.
+struct Tombstone
+{
+        //! Required. A server-defined message.
+        std::string body;
+        //! Required. The new room the client should be visiting.
+        std::string replacement_room;
+};
+
+//! Deserialization method needed by @p nlohmann::json.
+void
+from_json(const json &obj, Tombstone &content);
+
+//! Serialization method needed by @p nlohmann::json.
+void
+to_json(json &obj, const Tombstone &content);
+
+} // namespace state
+} // namespace events
+} // namespace mtx

--- a/include/mtxclient/crypto/client.hpp
+++ b/include/mtxclient/crypto/client.hpp
@@ -93,7 +93,7 @@ unpickle(const std::string &pickled, const std::string &key)
         if (ret == -1)
                 throw olm_exception("unpickle", object.get());
 
-        return std::move(object);
+        return object;
 }
 
 using OlmSessionPtr           = std::unique_ptr<OlmSession, OlmDeleter>;

--- a/include/mtxclient/http/client.hpp
+++ b/include/mtxclient/http/client.hpp
@@ -528,7 +528,7 @@ mtx::http::Client::create_session(HeadersCallback<Response> callback)
                   boost::signals2::signal<void()>::slot_type(&Session::terminate, session.get())
                     .track_foreign(session));
 
-        return std::move(session);
+        return session;
 }
 
 template<class Payload, mtx::events::EventType Event>

--- a/lib/structs/events.cpp
+++ b/lib/structs/events.cpp
@@ -42,6 +42,8 @@ getEventType(const std::string &type)
                 return EventType::RoomRedaction;
         else if (type == "m.room.pinned_events")
                 return EventType::RoomPinnedEvents;
+        else if (type == "m.room.tombstone")
+                return EventType::RoomTombstone;
         else if (type == "m.sticker")
                 return EventType::Sticker;
         else if (type == "m.tag")
@@ -88,6 +90,8 @@ to_string(EventType type)
                 return "m.room.redaction";
         case EventType::RoomPinnedEvents:
                 return "m.room.pinned_events";
+        case EventType::RoomTombstone:
+                return "m.room.tombstone";
         case EventType::Sticker:
                 return "m.sticker";
         case EventType::Tag:

--- a/lib/structs/events/create.cpp
+++ b/lib/structs/events/create.cpp
@@ -9,19 +9,42 @@ namespace events {
 namespace state {
 
 void
+from_json(const json &obj, PreviousRoom &predecessor)
+{
+        predecessor.room_id  = obj.at("room_id");
+        predecessor.event_id = obj.at("event_id");
+}
+void
+to_json(json &obj, const PreviousRoom &predecessor)
+{
+        obj["room_id"]  = predecessor.room_id;
+        obj["event_id"] = predecessor.event_id;
+}
+
+void
 from_json(const json &obj, Create &create)
 {
         create.creator = obj.at("creator");
 
         if (obj.find("m.federate") != obj.end())
                 create.federate = obj.at("m.federate").get<bool>();
+
+        if (obj.find("room_version") != obj.end())
+                create.room_version = obj.at("room_version");
+
+        if (obj.find("predecessor") != obj.end())
+                create.predecessor = obj.at("predecessor").get<PreviousRoom>();
 }
 
 void
 to_json(json &obj, const Create &create)
 {
-        obj["creator"]    = create.creator;
-        obj["m.federate"] = create.federate;
+        obj["creator"]      = create.creator;
+        obj["m.federate"]   = create.federate;
+        obj["room_version"] = create.room_version;
+
+        if (create.predecessor)
+                obj["predecessor"] = *create.predecessor;
 }
 
 } // namespace state

--- a/lib/structs/events/tombstone.cpp
+++ b/lib/structs/events/tombstone.cpp
@@ -1,0 +1,27 @@
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
+
+#include "mtx/events/tombstone.hpp"
+
+namespace mtx {
+namespace events {
+namespace state {
+
+void
+from_json(const json &obj, Tombstone &content)
+{
+        content.body             = obj.at("body");
+        content.replacement_room = obj.at("replacement_room");
+}
+
+void
+to_json(json &obj, const Tombstone &content)
+{
+        obj["body"]             = content.body;
+        obj["replacement_room"] = content.replacement_room;
+}
+
+} // namespace state
+} // namespace events
+} // namespace mtx

--- a/lib/structs/responses/common.cpp
+++ b/lib/structs/responses/common.cpp
@@ -93,6 +93,7 @@ parse_room_account_data_events(
                 case events::EventType::RoomMessage:
                 case events::EventType::RoomName:
                 case events::EventType::RoomPowerLevels:
+                case events::EventType::RoomTombstone:
                 case events::EventType::RoomTopic:
                 case events::EventType::RoomRedaction:
                 case events::EventType::RoomPinnedEvents:
@@ -227,6 +228,15 @@ parse_timeline_events(const json &events,
                         try {
                                 container.emplace_back(
                                   events::RedactionEvent<mtx::events::msg::Redaction>(e));
+                        } catch (json::exception &err) {
+                                log_error(err, e);
+                        }
+
+                        break;
+                }
+                case events::EventType::RoomTombstone: {
+                        try {
+                                container.emplace_back(events::StateEvent<Tombstone>(e));
                         } catch (json::exception &err) {
                                 log_error(err, e);
                         }
@@ -474,6 +484,15 @@ parse_state_events(const json &events,
 
                         break;
                 }
+                case events::EventType::RoomTombstone: {
+                        try {
+                                container.emplace_back(events::StateEvent<Tombstone>(e));
+                        } catch (json::exception &err) {
+                                log_error(err, e);
+                        }
+
+                        break;
+                }
                 case events::EventType::RoomTopic: {
                         try {
                                 container.emplace_back(events::StateEvent<Topic>(e));
@@ -591,6 +610,15 @@ parse_stripped_events(const json &events,
                 case events::EventType::RoomPowerLevels: {
                         try {
                                 container.emplace_back(events::StrippedEvent<PowerLevels>(e));
+                        } catch (json::exception &err) {
+                                log_error(err, e);
+                        }
+
+                        break;
+                }
+                case events::EventType::RoomTombstone: {
+                        try {
+                                container.emplace_back(events::StrippedEvent<Tombstone>(e));
                         } catch (json::exception &err) {
                                 log_error(err, e);
                         }

--- a/tests/events.cpp
+++ b/tests/events.cpp
@@ -51,6 +51,7 @@ TEST(Events, Conversions)
         EXPECT_EQ("m.room.name", ns::to_string(ns::EventType::RoomName));
         EXPECT_EQ("m.room.power_levels", ns::to_string(ns::EventType::RoomPowerLevels));
         EXPECT_EQ("m.room.topic", ns::to_string(ns::EventType::RoomTopic));
+        EXPECT_EQ("m.room.tombstone", ns::to_string(ns::EventType::RoomTombstone));
         EXPECT_EQ("m.room.redaction", ns::to_string(ns::EventType::RoomRedaction));
         EXPECT_EQ("m.room.pinned_events", ns::to_string(ns::EventType::RoomPinnedEvents));
         EXPECT_EQ("m.tag", ns::to_string(ns::EventType::Tag));
@@ -545,6 +546,37 @@ TEST(StateEvents, PowerLevels)
 
         EXPECT_EQ(event.content.user_level("@mujx:matrix.org"), 30);
         EXPECT_EQ(event.content.user_level("@not:matrix.org"), event.content.users_default);
+}
+
+TEST(StateEvents, Tombstone)
+{
+        json data = R"({
+            "content": {
+                "body": "This room has been replaced",
+                "replacement_room": "!newroom:example.org"
+            },
+            "event_id": "$143273582443PhrSn:example.org",
+            "origin_server_ts": 1432735824653,
+            "room_id": "!jEsUZKDJdhlrceRyVU:example.org",
+            "sender": "@example:example.org",
+            "state_key": "",
+            "type": "m.room.tombstone",
+            "unsigned": {
+                "age": 1234
+            }
+        })"_json;
+
+        ns::StateEvent<ns::state::Tombstone> event = data;
+
+        EXPECT_EQ(event.type, ns::EventType::RoomTombstone);
+        EXPECT_EQ(event.event_id, "$143273582443PhrSn:example.org");
+        EXPECT_EQ(event.room_id, "!jEsUZKDJdhlrceRyVU:example.org");
+        EXPECT_EQ(event.sender, "@example:example.org");
+        EXPECT_EQ(event.origin_server_ts, 1432735824653);
+        EXPECT_EQ(event.unsigned_data.age, 1234);
+        EXPECT_EQ(event.state_key, "");
+        EXPECT_EQ(event.content.body, "This room has been replaced");
+        EXPECT_EQ(event.content.replacement_room, "!newroom:example.org");
 }
 
 TEST(StateEvents, Topic)

--- a/tests/events.cpp
+++ b/tests/events.cpp
@@ -179,6 +179,41 @@ TEST(StateEvents, Create)
         EXPECT_EQ(event.origin_server_ts, 1506761923948L);
         EXPECT_EQ(event.state_key, "");
         EXPECT_EQ(event.content.creator, "@mujx:matrix.org");
+
+        json example_from_spec = R"({
+            "content": {
+                "creator": "@example:example.org",
+                "m.federate": true,
+                "predecessor": {
+                    "event_id": "$something:example.org",
+                    "room_id": "!oldroom:example.org"
+                },
+                "room_version": "1"
+            },
+            "event_id": "$143273582443PhrSn:example.org",
+            "origin_server_ts": 1432735824653,
+            "room_id": "!jEsUZKDJdhlrceRyVU:example.org",
+            "sender": "@example:example.org",
+            "state_key": "",
+            "type": "m.room.create",
+            "unsigned": {
+                "age": 1234
+            }
+        })"_json;
+
+        event = example_from_spec;
+
+        EXPECT_EQ(event.type, ns::EventType::RoomCreate);
+        EXPECT_EQ(event.event_id, "$143273582443PhrSn:example.org");
+        EXPECT_EQ(event.sender, "@example:example.org");
+        EXPECT_EQ(event.unsigned_data.age, 1234);
+        EXPECT_EQ(event.origin_server_ts, 1432735824653L);
+        EXPECT_EQ(event.state_key, "");
+        EXPECT_EQ(event.content.creator, "@example:example.org");
+        EXPECT_EQ(event.content.federate, true);
+        EXPECT_EQ(event.content.room_version, "1");
+        EXPECT_EQ(event.content.predecessor->room_id, "!oldroom:example.org");
+        EXPECT_EQ(event.content.predecessor->event_id, "$something:example.org");
 }
 
 TEST(StateEvents, GuestAccess)


### PR DESCRIPTION
This adds the event types and fields necessary to handle displaying, when a room has been upgraded. I hope I didn't miss anything, when adding the tombstone event type.