### PR TITLE
Do not create thumbnail info if there is no thumbnail

### DIFF
--- a/lib/structs/events/common.cpp
+++ b/lib/structs/events/common.cpp
@@ -64,8 +64,10 @@ to_json(json &obj, const ImageInfo &info)
         obj["w"]              = info.w;
         obj["size"]           = info.size;
         obj["mimetype"]       = info.mimetype;
-        obj["thumbnail_url"]  = info.thumbnail_url;
-        obj["thumbnail_info"] = info.thumbnail_info;
+        if (!info.thumbnail_url.empty()) {
+          obj["thumbnail_url"]  = info.thumbnail_url;
+          obj["thumbnail_info"] = info.thumbnail_info;
+        }
         if (info.thumbnail_file)
                 obj["thumbnail_file"] = info.thumbnail_file.value();
 }
@@ -94,8 +96,10 @@ to_json(json &obj, const FileInfo &info)
 {
         obj["size"]           = info.size;
         obj["mimetype"]       = info.mimetype;
-        obj["thumbnail_url"]  = info.thumbnail_url;
-        obj["thumbnail_info"] = info.thumbnail_info;
+        if (!info.thumbnail_url.empty()) {
+          obj["thumbnail_url"] = info.thumbnail_url;
+          obj["thumbnail_info"] = info.thumbnail_info;
+        }
         if (info.thumbnail_file)
                 obj["thumbnail_file"] = info.thumbnail_file.value();
 }

--- a/lib/structs/events/common.cpp
+++ b/lib/structs/events/common.cpp
@@ -60,13 +60,13 @@ from_json(const json &obj, ImageInfo &info)
 void
 to_json(json &obj, const ImageInfo &info)
 {
-        obj["h"]              = info.h;
-        obj["w"]              = info.w;
-        obj["size"]           = info.size;
-        obj["mimetype"]       = info.mimetype;
+        obj["h"]        = info.h;
+        obj["w"]        = info.w;
+        obj["size"]     = info.size;
+        obj["mimetype"] = info.mimetype;
         if (!info.thumbnail_url.empty()) {
-          obj["thumbnail_url"]  = info.thumbnail_url;
-          obj["thumbnail_info"] = info.thumbnail_info;
+                obj["thumbnail_url"]  = info.thumbnail_url;
+                obj["thumbnail_info"] = info.thumbnail_info;
         }
         if (info.thumbnail_file)
                 obj["thumbnail_file"] = info.thumbnail_file.value();
@@ -94,11 +94,11 @@ from_json(const json &obj, FileInfo &info)
 void
 to_json(json &obj, const FileInfo &info)
 {
-        obj["size"]           = info.size;
-        obj["mimetype"]       = info.mimetype;
+        obj["size"]     = info.size;
+        obj["mimetype"] = info.mimetype;
         if (!info.thumbnail_url.empty()) {
-          obj["thumbnail_url"] = info.thumbnail_url;
-          obj["thumbnail_info"] = info.thumbnail_info;
+                obj["thumbnail_url"]  = info.thumbnail_url;
+                obj["thumbnail_info"] = info.thumbnail_info;
         }
         if (info.thumbnail_file)
                 obj["thumbnail_file"] = info.thumbnail_file.value();

--- a/tests/messages.cpp
+++ b/tests/messages.cpp
@@ -130,7 +130,14 @@ TEST(RoomEvents, FileMessage)
             "body": "optimize.pdf",
             "info": {
               "mimetype": "application/pdf",
-              "size": 40565
+              "size": 40565,
+	      "thumbnail_info": {
+                "h": 200,
+                "mimetype": "image/png",
+                "size": 73602,
+                "w": 140
+              },
+	      "thumbnail_url": "mxc://matrix.org/XpxykZBESCSQnYkLKbbIKnVn"
             },
             "msgtype": "m.file",
             "url": "mxc://matrix.org/XpxykZBESCSQnYkLKbbIKnVn",
@@ -161,6 +168,15 @@ TEST(RoomEvents, FileMessage)
         EXPECT_EQ(event.content.info.size, 40565);
         EXPECT_EQ(event.content.relates_to.in_reply_to.event_id,
                   "$6GKhAfJOcwNd69lgSizdcTob8z2pWQgBOZPrnsWMA1E");
+
+        json withThumb = event;
+        EXPECT_EQ(withThumb["content"]["info"].count("thumbnail_url"), 1);
+        EXPECT_EQ(withThumb["content"]["info"].count("thumbnail_info"), 1);
+
+        event.content.info.thumbnail_url = "";
+        json withoutThumb                = event;
+        EXPECT_EQ(withoutThumb["content"]["info"].count("thumbnail_url"), 0);
+        EXPECT_EQ(withoutThumb["content"]["info"].count("thumbnail_info"), 0);
 }
 
 TEST(RoomEvents, EncryptedImageMessage)
@@ -300,6 +316,15 @@ TEST(RoomEvents, ImageMessage)
         EXPECT_EQ(event.content.info.thumbnail_info.size, 33504);
         EXPECT_EQ(event.content.relates_to.in_reply_to.event_id,
                   "$6GKhAfJOcwNd69lgSizdcTob8z2pWQgBOZPrnsWMA1E");
+
+        json withThumb = event;
+        EXPECT_EQ(withThumb["content"]["info"].count("thumbnail_url"), 1);
+        EXPECT_EQ(withThumb["content"]["info"].count("thumbnail_info"), 1);
+
+        event.content.info.thumbnail_url = "";
+        json withoutThumb                = event;
+        EXPECT_EQ(withoutThumb["content"]["info"].count("thumbnail_url"), 0);
+        EXPECT_EQ(withoutThumb["content"]["info"].count("thumbnail_info"), 0);
 }
 
 TEST(RoomEvents, LocationMessage) {}


### PR DESCRIPTION
This should fix a longstanding issue in nheko; where image messages without a thumbnail have an empty `thumbnail_info` causing riot and maybe other clients to not display the image.

---

cc @deepbluev7-old 