### PR TITLE
Add reaction JSON models

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,6 +185,7 @@ target_sources(matrix_client
 	lib/structs/events/name.cpp
 	lib/structs/events/pinned_events.cpp
 	lib/structs/events/power_levels.cpp
+	lib/structs/events/reaction.cpp
 	lib/structs/events/redaction.cpp
 	lib/structs/events/tag.cpp
 	lib/structs/events/tombstone.cpp

--- a/include/mtx/events.hpp
+++ b/include/mtx/events.hpp
@@ -24,6 +24,8 @@ enum class EventType
         KeyVerificationKey,
         /// m.key.verification.mac
         KeyVerificationMac,
+        /// m.reaction,
+        Reaction,
         /// m.room_key_request
         RoomKeyRequest,
         /// m.room.aliases
@@ -116,6 +118,9 @@ to_json(json &obj, const Event<Content> &event)
                 break;
         case EventType::KeyVerificationRequest:
                 obj["type"] = "m.key.verification.request";
+                break;
+        case EventType::Reaction:
+                obj["type"] = "m.reaction";
                 break;
         case EventType::RoomKeyRequest:
                 obj["type"] = "m.room_key_request";

--- a/include/mtx/events/collections.hpp
+++ b/include/mtx/events/collections.hpp
@@ -16,6 +16,7 @@
 #include "mtx/events/name.hpp"
 #include "mtx/events/pinned_events.hpp"
 #include "mtx/events/power_levels.hpp"
+#include "mtx/events/reaction.hpp"
 #include "mtx/events/redaction.hpp"
 #include "mtx/events/tag.hpp"
 #include "mtx/events/tombstone.hpp"
@@ -95,6 +96,7 @@ using TimelineEvents = std::variant<events::StateEvent<states::Aliases>,
                                     events::EncryptedEvent<msgs::Encrypted>,
                                     events::RedactionEvent<msgs::Redaction>,
                                     events::Sticker,
+                                    events::RoomEvent<msgs::Reaction>,
                                     events::RoomEvent<msgs::Redacted>,
                                     events::RoomEvent<msgs::Audio>,
                                     events::RoomEvent<msgs::Emote>,

--- a/include/mtx/events/common.hpp
+++ b/include/mtx/events/common.hpp
@@ -155,8 +155,27 @@ from_json(const nlohmann::json &obj, InReplyTo &in_reply_to);
 void
 to_json(nlohmann::json &obj, const InReplyTo &in_reply_to);
 
+//! Relates to for reactions
+struct ReactionRelatesTo
+{
+        // Type of relation
+        std::string rel_type;
+        // event id being reacted to
+        std::string event_id;
+        // key is the reaction itself
+        std::string key;
+};
+
+//! Deserialization method needed by @p nlohmann::json.
+void
+from_json(const nlohmann::json &obj, ReactionRelatesTo &relates_to);
+
+//! Serialization method needed by @p nlohmann::json.
+void
+to_json(nlohmann::json &obj, const ReactionRelatesTo &relates_to);
+
 //! Relates to data for rich replies (notice and text events)
-struct RelatesTo
+struct ReplyRelatesTo
 {
         //! What the message is in reply to
         InReplyTo in_reply_to;
@@ -164,11 +183,11 @@ struct RelatesTo
 
 //! Deserialization method needed by @p nlohmann::json.
 void
-from_json(const nlohmann::json &obj, RelatesTo &relates_to);
+from_json(const nlohmann::json &obj, ReplyRelatesTo &relates_to);
 
 //! Serialization method needed by @p nlohmann::json.
 void
-to_json(nlohmann::json &obj, const RelatesTo &relates_to);
+to_json(nlohmann::json &obj, const ReplyRelatesTo &relates_to);
 
 } // namespace common
 } // namespace mtx

--- a/include/mtx/events/common.hpp
+++ b/include/mtx/events/common.hpp
@@ -155,11 +155,30 @@ from_json(const nlohmann::json &obj, InReplyTo &in_reply_to);
 void
 to_json(nlohmann::json &obj, const InReplyTo &in_reply_to);
 
+//! Definition of rel_type for relations.
+enum class RelationType
+{
+        // m.annotation rel_type
+        Annotation,
+        // m.reference rel_type
+        Reference,
+        // m.replace rel_type
+        Replace,
+        // not one of the supported types
+        Unsupported
+};
+
+void
+from_json(const nlohmann::json &obj, RelationType &type);
+
+void
+to_json(nlohmann::json &obj, const RelationType &type);
+
 //! Relates to for reactions
 struct ReactionRelatesTo
 {
         // Type of relation
-        std::string rel_type;
+        RelationType rel_type;
         // event id being reacted to
         std::string event_id;
         // key is the reaction itself

--- a/include/mtx/events/encrypted.hpp
+++ b/include/mtx/events/encrypted.hpp
@@ -82,7 +82,7 @@ struct Encrypted
         //! Outbound group session id.
         std::string session_id;
         //! Relates to for rich replies
-        common::RelatesTo relates_to;
+        common::ReplyRelatesTo relates_to;
 };
 
 void

--- a/include/mtx/events/messages/audio.hpp
+++ b/include/mtx/events/messages/audio.hpp
@@ -30,7 +30,7 @@ struct Audio
         // Encryption members. If present, they replace url.
         std::optional<crypto::EncryptedFile> file;
         //! Relates to for rich replies
-        mtx::common::RelatesTo relates_to;
+        mtx::common::ReplyRelatesTo relates_to;
 };
 
 void

--- a/include/mtx/events/messages/emote.hpp
+++ b/include/mtx/events/messages/emote.hpp
@@ -25,7 +25,7 @@ struct Emote
         //! HTML formatted message.
         std::string formatted_body;
         //! Relates to for rich replies
-        mtx::common::RelatesTo relates_to;
+        mtx::common::ReplyRelatesTo relates_to;
 };
 
 void

--- a/include/mtx/events/messages/file.hpp
+++ b/include/mtx/events/messages/file.hpp
@@ -33,7 +33,7 @@ struct File
         // Encryption members. If present, they replace url.
         std::optional<crypto::EncryptedFile> file;
         //! Relates to for rich replies
-        mtx::common::RelatesTo relates_to;
+        mtx::common::ReplyRelatesTo relates_to;
 };
 
 void

--- a/include/mtx/events/messages/image.hpp
+++ b/include/mtx/events/messages/image.hpp
@@ -31,7 +31,7 @@ struct Image
         // Encryption members. If present, they replace url.
         std::optional<crypto::EncryptedFile> file;
         //! Relates to for rich replies
-        mtx::common::RelatesTo relates_to;
+        mtx::common::ReplyRelatesTo relates_to;
 };
 
 struct StickerImage
@@ -47,7 +47,7 @@ struct StickerImage
         // Encryption members. If present, they replace url.
         std::optional<crypto::EncryptedFile> file;
         //! Relates to for rich replies
-        mtx::common::RelatesTo relates_to;
+        mtx::common::ReplyRelatesTo relates_to;
 };
 
 void

--- a/include/mtx/events/messages/notice.hpp
+++ b/include/mtx/events/messages/notice.hpp
@@ -25,7 +25,7 @@ struct Notice
         //! HTML formatted message.
         std::string formatted_body;
         // Relates to for rich replies
-        mtx::common::RelatesTo relates_to;
+        mtx::common::ReplyRelatesTo relates_to;
 };
 
 void

--- a/include/mtx/events/messages/text.hpp
+++ b/include/mtx/events/messages/text.hpp
@@ -25,7 +25,7 @@ struct Text
         //! HTML formatted message.
         std::string formatted_body;
         //! Relates to for rich replies
-        mtx::common::RelatesTo relates_to;
+        mtx::common::ReplyRelatesTo relates_to;
 };
 
 void

--- a/include/mtx/events/messages/video.hpp
+++ b/include/mtx/events/messages/video.hpp
@@ -30,7 +30,7 @@ struct Video
         // Encryption members. If present, they replace url.
         std::optional<crypto::EncryptedFile> file;
         //! Relates to for rich replies
-        mtx::common::RelatesTo relates_to;
+        mtx::common::ReplyRelatesTo relates_to;
 };
 
 void

--- a/include/mtx/events/reaction.hpp
+++ b/include/mtx/events/reaction.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#if __has_include(<nlohmann/json_fwd.hpp>)
+#include <nlohmann/json_fwd.hpp>
+#else
+#include <nlohmann/json.hpp>
+#endif
+
+#include <string>
+
+#include "mtx/events/common.hpp"
+
+namespace mtx {
+namespace events {
+namespace msg {
+
+//! Content for the `m.reaction` event.
+struct Reaction
+{
+        //! The event being reacted to
+        mtx::common::ReactionRelatesTo relates_to;
+};
+
+void
+from_json(const nlohmann::json &obj, Reaction &event);
+
+void
+to_json(nlohmann::json &obj, const Reaction &event);
+
+} // namespace msg
+} // namespace events
+} // namespace mtx

--- a/lib/structs/events.cpp
+++ b/lib/structs/events.cpp
@@ -20,6 +20,8 @@ getEventType(const std::string &type)
                 return EventType::KeyVerificationMac;
         else if (type == "m.key.verification.cancel")
                 return EventType::KeyVerificationCancel;
+        else if (type == "m.reaction")
+                return EventType::Reaction;
         else if (type == "m.room_key_request")
                 return EventType::RoomKeyRequest;
         else if (type == "m.room.aliases")
@@ -82,6 +84,8 @@ to_string(EventType type)
                 return "m.key.verification.key";
         case EventType::KeyVerificationMac:
                 return "m.key.verification.mac";
+        case EventType::Reaction:
+                return "m.reaction";
         case EventType::RoomKeyRequest:
                 return "m.room_key_request";
         case EventType::RoomAliases:

--- a/lib/structs/events/collections.cpp
+++ b/lib/structs/events/collections.cpp
@@ -10,6 +10,10 @@ from_json(const json &obj, TimelineEvent &e)
         using namespace mtx::events::msg;
 
         switch (type) {
+        case events::EventType::Reaction: {
+                e.data = events::RoomEvent<Reaction>(obj);
+                break;
+        }
         case events::EventType::RoomAliases: {
                 e.data = events::StateEvent<Aliases>(obj);
                 break;

--- a/lib/structs/events/common.cpp
+++ b/lib/structs/events/common.cpp
@@ -183,10 +183,43 @@ to_json(json &obj, const InReplyTo &in_reply_to)
 }
 
 void
+to_json(json &obj, const RelationType &type)
+{
+        switch (type) {
+        case RelationType::Annotation:
+                obj = "m.annotation";
+                break;
+        case RelationType::Reference:
+                obj = "m.reference";
+                break;
+        case RelationType::Replace:
+                obj = "m.replace";
+                break;
+        case RelationType::Unsupported:
+        default:
+                obj = "unsupported";
+                break;
+        }
+}
+
+void
+from_json(const json &obj, RelationType &type)
+{
+        if (obj.get<std::string>() == "m.annotation")
+                type = RelationType::Annotation;
+        else if (obj.get<std::string>() == "m.reference")
+                type = RelationType::Reference;
+        else if (obj.get<std::string>() == "m.replace")
+                type = RelationType::Replace;
+        else
+                type = RelationType::Unsupported;
+}
+
+void
 from_json(const json &obj, ReactionRelatesTo &relates_to)
 {
         if (obj.find("rel_type") != obj.end())
-                relates_to.rel_type = obj.at("rel_type").get<std::string>();
+                relates_to.rel_type = obj.at("rel_type").get<RelationType>();
         if (obj.find("event_id") != obj.end())
                 relates_to.event_id = obj.at("event_id").get<std::string>();
         if (obj.find("key") != obj.end())

--- a/lib/structs/events/common.cpp
+++ b/lib/structs/events/common.cpp
@@ -183,14 +183,33 @@ to_json(json &obj, const InReplyTo &in_reply_to)
 }
 
 void
-from_json(const json &obj, RelatesTo &relates_to)
+from_json(const json &obj, ReactionRelatesTo &relates_to)
+{
+        if (obj.find("rel_type") != obj.end())
+                relates_to.rel_type = obj.at("rel_type").get<std::string>();
+        if (obj.find("event_id") != obj.end())
+                relates_to.event_id = obj.at("event_id").get<std::string>();
+        if (obj.find("key") != obj.end())
+                relates_to.key = obj.at("key").get<std::string>();
+}
+
+void
+to_json(json &obj, const ReactionRelatesTo &relates_to)
+{
+        obj["rel_type"] = relates_to.rel_type;
+        obj["event_id"] = relates_to.event_id;
+        obj["key"]      = relates_to.key;
+}
+
+void
+from_json(const json &obj, ReplyRelatesTo &relates_to)
 {
         if (obj.find("m.in_reply_to") != obj.end())
                 relates_to.in_reply_to = obj.at("m.in_reply_to").get<InReplyTo>();
 }
 
 void
-to_json(json &obj, const RelatesTo &relates_to)
+to_json(json &obj, const ReplyRelatesTo &relates_to)
 {
         obj["m.in_reply_to"] = relates_to.in_reply_to;
 }

--- a/lib/structs/events/encrypted.cpp
+++ b/lib/structs/events/encrypted.cpp
@@ -100,7 +100,7 @@ from_json(const json &obj, Encrypted &content)
         content.session_id = obj.at("session_id").get<std::string>();
 
         if (obj.count("m.relates_to") != 0)
-                content.relates_to = obj.at("m.relates_to").get<common::RelatesTo>();
+                content.relates_to = obj.at("m.relates_to").get<common::ReplyRelatesTo>();
 }
 
 void

--- a/lib/structs/events/messages/audio.cpp
+++ b/lib/structs/events/messages/audio.cpp
@@ -27,7 +27,7 @@ from_json(const json &obj, Audio &content)
                 content.file = obj.at("file").get<crypto::EncryptedFile>();
 
         if (obj.count("m.relates_to") != 0)
-                content.relates_to = obj.at("m.relates_to").get<common::RelatesTo>();
+                content.relates_to = obj.at("m.relates_to").get<common::ReplyRelatesTo>();
 }
 
 void

--- a/lib/structs/events/messages/emote.cpp
+++ b/lib/structs/events/messages/emote.cpp
@@ -23,7 +23,7 @@ from_json(const json &obj, Emote &content)
                 content.formatted_body = obj.at("formatted_body").get<std::string>();
 
         if (obj.count("m.relates_to") != 0)
-                content.relates_to = obj.at("m.relates_to").get<common::RelatesTo>();
+                content.relates_to = obj.at("m.relates_to").get<common::ReplyRelatesTo>();
 }
 
 void

--- a/lib/structs/events/messages/file.cpp
+++ b/lib/structs/events/messages/file.cpp
@@ -30,7 +30,7 @@ from_json(const json &obj, File &content)
                 content.file = obj.at("file").get<crypto::EncryptedFile>();
 
         if (obj.count("m.relates_to") != 0)
-                content.relates_to = obj.at("m.relates_to").get<common::RelatesTo>();
+                content.relates_to = obj.at("m.relates_to").get<common::ReplyRelatesTo>();
 }
 
 void

--- a/lib/structs/events/messages/image.cpp
+++ b/lib/structs/events/messages/image.cpp
@@ -26,7 +26,7 @@ from_json(const json &obj, Image &content)
                 content.file = obj.at("file").get<crypto::EncryptedFile>();
 
         if (obj.count("m.relates_to") != 0)
-                content.relates_to = obj.at("m.relates_to").get<common::RelatesTo>();
+                content.relates_to = obj.at("m.relates_to").get<common::ReplyRelatesTo>();
 }
 
 void
@@ -58,7 +58,7 @@ from_json(const json &obj, StickerImage &content)
                 content.file = obj.at("file").get<crypto::EncryptedFile>();
 
         if (obj.count("m.relates_to") != 0)
-                content.relates_to = obj.at("m.relates_to").get<common::RelatesTo>();
+                content.relates_to = obj.at("m.relates_to").get<common::ReplyRelatesTo>();
 }
 
 void

--- a/lib/structs/events/messages/notice.cpp
+++ b/lib/structs/events/messages/notice.cpp
@@ -23,7 +23,7 @@ from_json(const json &obj, Notice &content)
                 content.formatted_body = obj.at("formatted_body").get<std::string>();
 
         if (obj.count("m.relates_to") != 0)
-                content.relates_to = obj.at("m.relates_to").get<common::RelatesTo>();
+                content.relates_to = obj.at("m.relates_to").get<common::ReplyRelatesTo>();
 }
 
 void

--- a/lib/structs/events/messages/text.cpp
+++ b/lib/structs/events/messages/text.cpp
@@ -23,7 +23,7 @@ from_json(const json &obj, Text &content)
                 content.formatted_body = obj.at("formatted_body").get<std::string>();
 
         if (obj.count("m.relates_to") != 0)
-                content.relates_to = obj.at("m.relates_to").get<common::RelatesTo>();
+                content.relates_to = obj.at("m.relates_to").get<common::ReplyRelatesTo>();
 }
 
 void

--- a/lib/structs/events/messages/video.cpp
+++ b/lib/structs/events/messages/video.cpp
@@ -28,7 +28,7 @@ from_json(const json &obj, Video &content)
                 content.file = obj.at("file").get<crypto::EncryptedFile>();
 
         if (obj.count("m.relates_to") != 0)
-                content.relates_to = obj.at("m.relates_to").get<common::RelatesTo>();
+                content.relates_to = obj.at("m.relates_to").get<common::ReplyRelatesTo>();
 }
 
 void

--- a/lib/structs/events/reaction.cpp
+++ b/lib/structs/events/reaction.cpp
@@ -1,0 +1,27 @@
+#include <nlohmann/json.hpp>
+#include <string>
+
+#include "mtx/events/reaction.hpp"
+
+using json = nlohmann::json;
+
+namespace mtx {
+namespace events {
+namespace msg {
+
+void
+from_json(const json &obj, Reaction &event)
+{
+        if (obj.count("m.relates_to") != 0)
+                event.relates_to = obj.at("m.relates_to").get<common::ReactionRelatesTo>();
+}
+
+void
+to_json(json &obj, const Reaction &event)
+{
+        obj["m.relates_to"] = event.relates_to;
+}
+
+} // namespace msg
+} // namespace events
+} // namespace mtx

--- a/tests/messages.cpp
+++ b/tests/messages.cpp
@@ -38,7 +38,7 @@ TEST(RoomEvents, Reaction)
         EXPECT_EQ(event.content.relates_to.event_id,
                   "$oGKg0tfsnDamWPsGxUptGLWR5b8Xq6QNFFsysQNSnake");
         EXPECT_EQ(event.content.relates_to.key, "👀");
-        EXPECT_EQ(event.content.relates_to.rel_type, "m.annotation");
+        EXPECT_EQ(event.content.relates_to.rel_type, mtx::common::RelationType::Annotation);
 
         EXPECT_EQ(data.dump(), json(event).dump());
 };

--- a/tests/messages.cpp
+++ b/tests/messages.cpp
@@ -7,6 +7,40 @@ using json = nlohmann::json;
 
 using namespace mtx::events;
 
+TEST(RoomEvents, Reaction)
+{
+        json data = R"({
+  "type": "m.reaction",
+  "room_id": "!CYvyeleADEeDAsndMom:localhost",
+  "sender": "@example:localhost",
+  "content": {
+    "m.relates_to": {
+      "rel_type": "m.annotation",
+      "event_id": "$oGKg0tfsnDamWPsGxUptGLWR5b8Xq6QNFFsysQNSnake",
+      "key": "👀"
+    }
+  },
+  "origin_server_ts": 1588536414112,
+  "unsigned": {
+    "age": 1905609
+  },
+  "event_id": "$ujXAq1WXebS-vcpA4yBIZPvCeqGvnrMFP1c1qn8_wJump"
+  })"_json;
+
+        RoomEvent<msg::Reaction> event = data;
+
+        EXPECT_EQ(event.type, EventType::Reaction);
+        EXPECT_EQ(event.event_id, "$ujXAq1WXebS-vcpA4yBIZPvCeqGvnrMFP1c1qn8_wJump");
+        EXPECT_EQ(event.room_id, "!CYvyeleADEeDAsndMom:localhost");
+        EXPECT_EQ(event.sender, "@example:localhost");
+        EXPECT_EQ(event.origin_server_ts, 1588536414112L);
+        EXPECT_EQ(event.unsigned_data.age, 1905609L);
+        EXPECT_EQ(event.content.relates_to.event_id,
+                  "$oGKg0tfsnDamWPsGxUptGLWR5b8Xq6QNFFsysQNSnake");
+        EXPECT_EQ(event.content.relates_to.key, "👀");
+        EXPECT_EQ(event.content.relates_to.rel_type, "m.annotation");
+};
+
 TEST(RoomEvents, Redacted)
 {
         json data = R"({
@@ -459,6 +493,8 @@ TEST(RoomEvents, TextMessage)
         EXPECT_EQ(event.content.msgtype, "m.text");
         EXPECT_EQ(event.content.relates_to.in_reply_to.event_id,
                   "$6GKhAfJOcwNd69lgSizdcTob8z2pWQgBOZPrnsWMA1E");
+
+        EXPECT_EQ(data.dump(), json(event).dump());
 }
 
 TEST(RoomEvents, VideoMessage)

--- a/tests/messages.cpp
+++ b/tests/messages.cpp
@@ -39,6 +39,8 @@ TEST(RoomEvents, Reaction)
                   "$oGKg0tfsnDamWPsGxUptGLWR5b8Xq6QNFFsysQNSnake");
         EXPECT_EQ(event.content.relates_to.key, "👀");
         EXPECT_EQ(event.content.relates_to.rel_type, "m.annotation");
+
+        EXPECT_EQ(data.dump(), json(event).dump());
 };
 
 TEST(RoomEvents, Redacted)


### PR DESCRIPTION
Rename RelatesTo for reply messages

There's room for improvements:
* maybe use a variant for the various RelatesTo types
* ~Use an enum for ReactionRelatesTo.rel_type (currently std::string)~ Done