### PR TITLE
Add nheko specific account data type for hiding event types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,6 +169,7 @@ target_sources(matrix_client
 	lib/structs/events/tombstone.cpp
 	lib/structs/events/topic.cpp
 	lib/structs/events/voip.cpp
+	lib/structs/events/nheko_extensions/hidden_events.cpp
 	lib/structs/events/messages/audio.cpp
 	lib/structs/events/messages/emote.cpp
 	lib/structs/events/messages/file.cpp

--- a/include/mtx/events.hpp
+++ b/include/mtx/events.hpp
@@ -84,6 +84,11 @@ enum class EventType
         CallAnswer,
         // m.call.hangup
         CallHangUp,
+
+        // custom events
+        // im.nheko.hidden_events
+        NhekoHiddenEvents,
+
         // Unsupported event
         Unsupported,
 };

--- a/include/mtx/events/collections.hpp
+++ b/include/mtx/events/collections.hpp
@@ -14,6 +14,7 @@
 #include "mtx/events/join_rules.hpp"
 #include "mtx/events/member.hpp"
 #include "mtx/events/name.hpp"
+#include "mtx/events/nheko_extensions/hidden_events.hpp"
 #include "mtx/events/pinned_events.hpp"
 #include "mtx/events/power_levels.hpp"
 #include "mtx/events/presence.hpp"
@@ -59,7 +60,9 @@ using DeviceEvents = std::variant<events::DeviceEvent<msgs::RoomKey>,
 
 //! Collection of room specific account data
 using RoomAccountDataEvents =
-  std::variant<events::Event<account_data::Tags>, events::Event<pushrules::GlobalRuleset>>;
+  std::variant<events::Event<account_data::Tags>,
+               events::Event<pushrules::GlobalRuleset>,
+               events::Event<account_data::nheko_extensions::HiddenEvents>>;
 
 //! Collection of @p StateEvent only.
 using StateEvents = std::variant<events::StateEvent<states::Aliases>,

--- a/include/mtx/events/nheko_extensions/hidden_events.hpp
+++ b/include/mtx/events/nheko_extensions/hidden_events.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include "mtx/events.hpp"
+
+namespace mtx {
+namespace events {
+namespace account_data {
+namespace nheko_extensions {
+//! Custom event to hide certain event types in nheko
+struct HiddenEvents
+{
+        //! The hidden event types
+        std::vector<EventType> hidden_event_types;
+};
+
+void
+from_json(const nlohmann::json &obj, HiddenEvents &content);
+
+void
+to_json(nlohmann::json &obj, const HiddenEvents &content);
+}
+} // namespace account_data
+} // namespace events
+} // namespace mtx

--- a/include/mtx/events/tag.hpp
+++ b/include/mtx/events/tag.hpp
@@ -5,8 +5,6 @@
 
 #include <nlohmann/json.hpp>
 
-using json = nlohmann::json;
-
 namespace mtx {
 namespace events {
 namespace account_data {
@@ -17,10 +15,10 @@ struct Tag
         std::optional<double> order;
 };
 void
-from_json(const json &obj, Tag &content);
+from_json(const nlohmann::json &obj, Tag &content);
 
 void
-to_json(json &obj, const Tag &content);
+to_json(nlohmann::json &obj, const Tag &content);
 
 //! Content for the `m.tag` room account_data event.
 //! A tag is a short string a client can attach to a room for sorting or advanced functionality.
@@ -31,10 +29,10 @@ struct Tags
 };
 
 void
-from_json(const json &obj, Tags &content);
+from_json(const nlohmann::json &obj, Tags &content);
 
 void
-to_json(json &obj, const Tags &content);
+to_json(nlohmann::json &obj, const Tags &content);
 
 } // namespace account_data
 } // namespace events

--- a/include/mtx/responses/sync.hpp
+++ b/include/mtx/responses/sync.hpp
@@ -12,14 +12,14 @@ namespace mtx {
 namespace responses {
 
 //! Room specific Account Data events.
-struct RoomAccountData
+struct AccountData
 {
         //! List of events.
         std::vector<events::collections::RoomAccountDataEvents> events;
 };
 
 void
-from_json(const nlohmann::json &obj, RoomAccountData &account_data);
+from_json(const nlohmann::json &obj, AccountData &account_data);
 
 //! State events.
 struct State
@@ -88,7 +88,7 @@ struct JoinedRoom
         //! timeline or state of the room. e.g. typing.
         Ephemeral ephemeral;
         //! The account_data events associated with this room.
-        RoomAccountData account_data;
+        AccountData account_data;
 };
 
 void
@@ -178,7 +178,8 @@ struct Sync
         //! A mapping from algorithm to the number of one time keys
         //! the server has for the current device.
         std::map<std::string, uint16_t> device_one_time_keys_count;
-        /* AccountData account_data; */
+        //! global account data
+        AccountData account_data;
 };
 
 void

--- a/include/mtxclient/http/client.hpp
+++ b/include/mtxclient/http/client.hpp
@@ -723,8 +723,8 @@ mtx::http::Client::send_room_message(const std::string &room_id,
         constexpr auto event_type = mtx::events::message_content_to_type<Payload>;
         static_assert(event_type != mtx::events::EventType::Unsupported);
 
-        const auto api_path = "/client/r0/rooms/" + room_id + "/send/" +
-                              mtx::events::to_string(event_type) + "/" +
+        const auto api_path = "/client/r0/rooms/" + mtx::client::utils::url_encode(room_id) +
+                              "/send/" + mtx::events::to_string(event_type) + "/" +
                               mtx::client::utils::url_encode(txn_id);
 
         put<Payload, mtx::responses::EventId>(api_path, payload, callback);

--- a/lib/structs/events.cpp
+++ b/lib/structs/events.cpp
@@ -78,6 +78,8 @@ getEventType(const std::string &type)
                 return EventType::CallAnswer;
         else if (type == "m.call.hangup")
                 return EventType::CallHangUp;
+        else if (type == "im.nheko.hidden_events")
+                return EventType::NhekoHiddenEvents;
 
         return EventType::Unsupported;
 }
@@ -158,6 +160,8 @@ to_string(EventType type)
                 return "m.call.answer";
         case EventType::CallHangUp:
                 return "m.call.hangup";
+        case EventType::NhekoHiddenEvents:
+                return "im.nheko.hidden_events";
         case EventType::Unsupported:
                 return "";
         }

--- a/lib/structs/events/collections.cpp
+++ b/lib/structs/events/collections.cpp
@@ -176,6 +176,7 @@ from_json(const json &obj, TimelineEvent &e)
         case events::EventType::KeyVerificationAccept:
         case events::EventType::KeyVerificationKey:
         case events::EventType::KeyVerificationMac:
+        case events::EventType::NhekoHiddenEvents:
         case events::EventType::Unsupported:
                 return;
         }

--- a/lib/structs/events/nheko_extensions/hidden_events.cpp
+++ b/lib/structs/events/nheko_extensions/hidden_events.cpp
@@ -1,0 +1,28 @@
+#include "mtx/events/nheko_extensions/hidden_events.hpp"
+
+namespace mtx {
+namespace events {
+namespace account_data {
+namespace nheko_extensions {
+
+void
+from_json(const nlohmann::json &obj, HiddenEvents &content)
+{
+        for (const auto &typeStr : obj.at("hidden_event_types")) {
+                if (auto type = getEventType(typeStr.get<std::string>());
+                    type != EventType::Unsupported)
+                        content.hidden_event_types.push_back(type);
+        }
+}
+
+void
+to_json(nlohmann::json &obj, const HiddenEvents &content)
+{
+        for (auto type : content.hidden_event_types) {
+                obj["hidden_event_types"].push_back(to_string(type));
+        }
+}
+}
+} // namespace account_data
+} // namespace events
+} // namespace mtx

--- a/lib/structs/responses/common.cpp
+++ b/lib/structs/responses/common.cpp
@@ -276,6 +276,15 @@ parse_room_account_data_events(
                         }
                         break;
                 }
+                case events::EventType::NhekoHiddenEvents: {
+                        try {
+                                container.emplace_back(
+                                  events::Event<nheko_extensions::HiddenEvents>(e));
+                        } catch (json::exception &err) {
+                                log_error(err, e);
+                        }
+                        break;
+                }
                 case events::EventType::KeyVerificationCancel:
                 case events::EventType::KeyVerificationRequest:
                 case events::EventType::KeyVerificationStart:
@@ -649,6 +658,7 @@ parse_timeline_events(const json &events,
                 case events::EventType::KeyVerificationAccept:
                 case events::EventType::KeyVerificationKey:
                 case events::EventType::KeyVerificationMac:
+                case events::EventType::NhekoHiddenEvents:
                         continue;
                 }
         }
@@ -930,6 +940,7 @@ parse_state_events(const json &events,
                 case events::EventType::CallCandidates:
                 case events::EventType::CallAnswer:
                 case events::EventType::CallHangUp:
+                case events::EventType::NhekoHiddenEvents:
                         continue;
                 }
         }
@@ -1079,6 +1090,7 @@ parse_stripped_events(const json &events,
                 case events::EventType::CallCandidates:
                 case events::EventType::CallAnswer:
                 case events::EventType::CallHangUp:
+                case events::EventType::NhekoHiddenEvents:
                         continue;
                 }
         }

--- a/lib/structs/responses/sync.cpp
+++ b/lib/structs/responses/sync.cpp
@@ -11,7 +11,7 @@ namespace mtx {
 namespace responses {
 
 void
-from_json(const json &obj, RoomAccountData &account_data)
+from_json(const json &obj, AccountData &account_data)
 {
         utils::parse_room_account_data_events(obj.at("events"), account_data.events);
 }
@@ -107,7 +107,7 @@ from_json(const json &obj, JoinedRoom &room)
 
         if (obj.count("account_data") != 0) {
                 if (obj.at("account_data").count("events") != 0)
-                        room.account_data = obj.at("account_data").get<RoomAccountData>();
+                        room.account_data = obj.at("account_data").get<AccountData>();
         }
 }
 
@@ -240,6 +240,11 @@ from_json(const json &obj, Sync &response)
                   obj.at("presence")
                     .at("events")
                     .get<std::vector<mtx::events::Event<mtx::events::presence::Presence>>>();
+        }
+
+        if (obj.count("account_data") != 0) {
+                if (obj.at("account_data").count("events") != 0)
+                        response.account_data = obj.at("account_data").get<AccountData>();
         }
 
         response.next_batch = obj.at("next_batch").get<std::string>();

--- a/lib/structs/responses/sync.cpp
+++ b/lib/structs/responses/sync.cpp
@@ -180,24 +180,15 @@ void
 from_json(const json &obj, Rooms &rooms)
 {
         if (obj.count("join") != 0) {
-                auto joined = obj.at("join");
-
-                for (auto it = joined.begin(); it != joined.end(); ++it)
-                        rooms.join.emplace(it.key(), it.value());
+                rooms.join = obj.at("join").get<std::map<std::string, JoinedRoom>>();
         }
 
         if (obj.count("leave") != 0) {
-                auto leave = obj.at("leave");
-
-                for (auto it = leave.begin(); it != leave.end(); ++it)
-                        rooms.leave.emplace(it.key(), it.value());
+		rooms.leave = obj.at("leave").get<std::map<std::string, LeftRoom>>();
         }
 
         if (obj.count("invite") != 0) {
-                auto invite = obj.at("invite");
-
-                for (auto it = invite.begin(); it != invite.end(); ++it)
-                        rooms.invite.emplace(it.key(), it.value());
+		rooms.invite = obj.at("invite").get<std::map<std::string, InvitedRoom>>();
         }
 }
 

--- a/tests/events.cpp
+++ b/tests/events.cpp
@@ -1145,6 +1145,26 @@ TEST(RoomAccountData, Tags)
         EXPECT_EQ(event.content.tags.at("com.example.nheko.text").order, std::nullopt);
 }
 
+TEST(RoomAccountData, NhekoHiddenEvents)
+{
+        json data = R"({
+          "content": {
+              "hidden_event_types": [
+	          "m.reaction",
+		  "m.room.member"
+	      ]
+          },
+          "type": "im.nheko.hidden_events"
+        })"_json;
+
+        ns::Event<ns::account_data::nheko_extensions::HiddenEvents> event = data;
+
+        EXPECT_EQ(event.type, ns::EventType::NhekoHiddenEvents);
+        EXPECT_EQ(event.content.hidden_event_types.size(), 2);
+        EXPECT_EQ(event.content.hidden_event_types[0], ns::EventType::Reaction);
+        EXPECT_EQ(event.content.hidden_event_types[1], ns::EventType::RoomMember);
+}
+
 TEST(Presence, Presence)
 {
         json data = R"({


### PR DESCRIPTION
This is needed to allow storing what event types get hidden in account_data. This can be stored globally or per room.