### PR TITLE
Voip fixes

### DIFF
--- a/include/mtx/events/collections.hpp
+++ b/include/mtx/events/collections.hpp
@@ -163,6 +163,15 @@ template<>
 constexpr EventType message_content_to_type<mtx::events::msg::Video> = EventType::RoomMessage;
 template<>
 constexpr EventType message_content_to_type<mtx::events::msg::StickerImage> = EventType::Sticker;
+template<>
+constexpr EventType message_content_to_type<mtx::events::msg::CallInvite> = EventType::CallInvite;
+template<>
+constexpr EventType message_content_to_type<mtx::events::msg::CallCandidates> =
+  EventType::CallCandidates;
+template<>
+constexpr EventType message_content_to_type<mtx::events::msg::CallAnswer> = EventType::CallAnswer;
+template<>
+constexpr EventType message_content_to_type<mtx::events::msg::CallHangUp> = EventType::CallHangUp;
 
 template<typename Content>
 constexpr EventType state_content_to_type = EventType::Unsupported;

--- a/include/mtx/events/collections.hpp
+++ b/include/mtx/events/collections.hpp
@@ -164,14 +164,14 @@ constexpr EventType message_content_to_type<mtx::events::msg::Video> = EventType
 template<>
 constexpr EventType message_content_to_type<mtx::events::msg::StickerImage> = EventType::Sticker;
 template<>
-constexpr EventType message_content_to_type<mtx::events::msg::CallInvite> = EventType::CallInvite;
+constexpr inline EventType message_content_to_type<mtx::events::msg::CallInvite> = EventType::CallInvite;
 template<>
-constexpr EventType message_content_to_type<mtx::events::msg::CallCandidates> =
+constexpr inline EventType message_content_to_type<mtx::events::msg::CallCandidates> =
   EventType::CallCandidates;
 template<>
-constexpr EventType message_content_to_type<mtx::events::msg::CallAnswer> = EventType::CallAnswer;
+constexpr inline EventType message_content_to_type<mtx::events::msg::CallAnswer> = EventType::CallAnswer;
 template<>
-constexpr EventType message_content_to_type<mtx::events::msg::CallHangUp> = EventType::CallHangUp;
+constexpr inline EventType message_content_to_type<mtx::events::msg::CallHangUp> = EventType::CallHangUp;
 
 template<typename Content>
 constexpr EventType state_content_to_type = EventType::Unsupported;

--- a/include/mtx/events/collections.hpp
+++ b/include/mtx/events/collections.hpp
@@ -164,14 +164,17 @@ constexpr EventType message_content_to_type<mtx::events::msg::Video> = EventType
 template<>
 constexpr EventType message_content_to_type<mtx::events::msg::StickerImage> = EventType::Sticker;
 template<>
-constexpr inline EventType message_content_to_type<mtx::events::msg::CallInvite> = EventType::CallInvite;
+constexpr inline EventType message_content_to_type<mtx::events::msg::CallInvite> =
+  EventType::CallInvite;
 template<>
 constexpr inline EventType message_content_to_type<mtx::events::msg::CallCandidates> =
   EventType::CallCandidates;
 template<>
-constexpr inline EventType message_content_to_type<mtx::events::msg::CallAnswer> = EventType::CallAnswer;
+constexpr inline EventType message_content_to_type<mtx::events::msg::CallAnswer> =
+  EventType::CallAnswer;
 template<>
-constexpr inline EventType message_content_to_type<mtx::events::msg::CallHangUp> = EventType::CallHangUp;
+constexpr inline EventType message_content_to_type<mtx::events::msg::CallHangUp> =
+  EventType::CallHangUp;
 
 template<typename Content>
 constexpr EventType state_content_to_type = EventType::Unsupported;


### PR DESCRIPTION
Fixes Nheko voice calls on master (voip events currently don't send). Guess we'll need a branch since Nheko master doesn't build against latest mtxclient.