### PR TITLE
Add set pushers endpoint

### DIFF
--- a/include/mtx/requests.hpp
+++ b/include/mtx/requests.hpp
@@ -254,5 +254,48 @@ struct KeySignaturesUpload
 
 void
 to_json(json &obj, const KeySignaturesUpload &req);
+
+struct PusherData {
+        //! Required if `kind` is http. The URL to use to send notifications to.
+        //! MUST be an HTTPS URL with a path of /_matrix/push/v1/notify.
+        std::string url;
+        //! The format to send notifications in to Push Gateways if the kind is http.
+        //! The details about what fields the homeserver should send to the push gateway are
+        //! defined in the Push Gateway Specification. Currently the only format available is
+        //! 'event_id_only'.
+        std::string format;
+};
+
+void
+to_json(json &obj, const PusherData &data);
+
+//! Request payload for the `POST /_matrix/client/r0/pushers/set` endpoint.
+struct SetPusher {
+        //! Required. Unique identifier for this pusher.
+        std::string pushkey;
+        //! Required. The kind of pusher to configure. "http" makes a pusher that sends HTTP pokes.
+        //! "email" makes a pusher that emails the user with unread notifications.
+        //! null deletes the pusher.
+        std::string kind;
+        //! Required. This is a reverse-DNS style identifier for the application.
+        //! If the `kind` is "email", this is "m.email".
+        std::string app_id;
+        //! Required. A string that will allow the user to identify what application owns this pusher.
+        std::string app_display_name;
+        //! Required. A string that will allow the user to identify what device owns this pusher.
+        std::string device_display_name;
+        //! Determines which set of device specific rules this pusher executes.
+        std::string profile_tag;
+        //! Required. The preferred language for receiving notifications.
+        std::string lang;
+        //! Required. Data for the pusher implementation (for example, if `kind` is `http`, includes
+        //! the URL to push to).
+        PusherData data;
+        //! If true, add another pusher instead of updating an existing one.
+        bool append = false;
+};
+
+void
+to_json(json &obj, const SetPusher &req);
 } // namespace requests
 } // namespace mtx

--- a/include/mtxclient/http/client.hpp
+++ b/include/mtxclient/http/client.hpp
@@ -49,6 +49,8 @@ struct ClaimKeys;
 struct UploadKeys;
 struct PublicRoomVisibility;
 struct PublicRooms;
+struct PushersData;
+struct SetPushers;
 }
 namespace responses {
 struct AvatarUrl;
@@ -557,6 +559,10 @@ public:
 
         //! Gets any TURN server URIs and authentication credentials
         void get_turn_server(Callback<mtx::responses::TurnServer> cb);
+
+        //! Sets, updates, or deletes a pusher
+        void set_pusher(const mtx::requests::SetPusher &req,
+                        Callback<mtx::responses::Empty> cb);
 
 private:
         template<class Request, class Response>

--- a/lib/http/client.cpp
+++ b/lib/http/client.cpp
@@ -1266,6 +1266,12 @@ Client::get_turn_server(Callback<mtx::responses::TurnServer> cb)
                                              RequestErr err) { cb(res, err); });
 }
 
+void
+Client::set_pusher(const mtx::requests::SetPusher &req, Callback<mtx::responses::Empty> cb)
+{
+        post<mtx::requests::SetPusher, mtx::responses::Empty>("/client/r0/pushers/set", req, cb);
+}
+
 // Template instantiations for the various send functions
 
 #define MTXCLIENT_SEND_STATE_EVENT(Content)                                                        \

--- a/lib/structs/requests.cpp
+++ b/lib/structs/requests.cpp
@@ -187,5 +187,33 @@ to_json(json &obj, const KeySignaturesUpload &req)
                           std::visit([](const auto &e) { return json(e); }, keyVar);
 }
 
+
+void
+to_json(json &obj, const PusherData &data)
+{
+        if (!data.url.empty()) {
+                obj["url"] = data.url;
+        }
+        if (!data.format.empty()) {
+                obj["format"] = data.format;
+        }
+}
+
+void
+to_json(json &obj, const SetPusher &req)
+{
+        obj["pushkey"] = req.pushkey;
+        obj["kind"] = req.kind;
+        obj["app_id"] = req.app_id;
+        obj["app_display_name"] = req.app_display_name;
+        obj["device_display_name"] = req.device_display_name;
+        if (!req.profile_tag.empty()) {
+                obj["profile_tag"] = req.profile_tag;
+        }
+        obj["lang"] = req.lang;
+        obj["data"] = req.data;
+        obj["append"] = req.append;
+}
+
 } // namespace requests
 } // namespace mtx


### PR DESCRIPTION
Adds the endpoint [POST /_matrix/client/r0/pushers/set](https://matrix.org/docs/spec/client_server/r0.6.1#post-matrix-client-r0-pushers-set) for setting, updating, or deleting a pusher.