### PR TITLE
Support registration token validity checking

### DIFF
--- a/include/mtx/responses/register.hpp
+++ b/include/mtx/responses/register.hpp
@@ -31,5 +31,17 @@ struct Register
 
 void
 from_json(const nlohmann::json &obj, Register &response);
+
+//! Response from the `GET
+//! /_matrix/client/unstable/org.matrix.msc3231/register/org.matrix.msc3231.login.registration_token/validity`
+//! endpoint.
+struct RegistrationTokenValidity
+{
+        //! Whether the registration token is valid or not
+        bool valid;
+};
+
+void
+from_json(const nlohmann::json &obj, RegistrationTokenValidity &response);
 }
 }

--- a/include/mtxclient/http/client.hpp
+++ b/include/mtxclient/http/client.hpp
@@ -70,6 +70,7 @@ struct Notifications;
 struct Profile;
 struct QueryKeys;
 struct Register;
+struct RegistrationTokenValidity;
 struct Sync;
 struct TurnServer;
 struct UploadKeys;
@@ -240,6 +241,10 @@ public:
                           const std::string &pass,
                           const user_interactive::Auth &auth,
                           Callback<mtx::responses::Register> cb);
+
+        //! Check the validity of a registration token
+        void registration_token_validity(const std::string token,
+                                         Callback<mtx::responses::RegistrationTokenValidity> cb);
 
         //! Paginate through the list of events that the user has been,
         //! or would have been notified about.

--- a/lib/http/client.cpp
+++ b/lib/http/client.cpp
@@ -891,6 +891,21 @@ Client::registration(const std::string &user,
 }
 
 void
+Client::registration_token_validity(const std::string token,
+                                    Callback<mtx::responses::RegistrationTokenValidity> cb)
+{
+        const auto api_path = "/client/unstable/org.matrix.msc3231/register/"
+                              "org.matrix.msc3231.login.registration_token/validity?" +
+                              mtx::client::utils::query_params({{"token", token}});
+
+        get<mtx::responses::RegistrationTokenValidity>(
+          api_path,
+          [cb](const mtx::responses::RegistrationTokenValidity &res, HeaderFields, RequestErr err) {
+                  cb(res, err);
+          });
+}
+
+void
 Client::send_state_event(const std::string &room_id,
                          const std::string &event_type,
                          const std::string &state_key,

--- a/lib/structs/responses/register.cpp
+++ b/lib/structs/responses/register.cpp
@@ -15,5 +15,11 @@ from_json(const json &obj, Register &response)
         response.access_token = obj.at("access_token").get<std::string>();
         response.device_id    = obj.at("device_id").get<std::string>();
 }
+
+void
+from_json(const nlohmann::json &obj, RegistrationTokenValidity &response)
+{
+        response.valid = obj.at("valid").get<bool>();
+}
 }
 }

--- a/tests/responses.cpp
+++ b/tests/responses.cpp
@@ -476,6 +476,14 @@ TEST(Responses, WellKnown)
         EXPECT_EQ(wellknown.identity_server->base_url, "https://identity.example.com");
 }
 
+TEST(Responses, RegistrationTokenValidity)
+{
+        json data = R"({"valid" : true})"_json;
+
+        RegistrationTokenValidity validity = data;
+        EXPECT_EQ(validity.valid, true);
+}
+
 TEST(Responses, CreateRoom)
 {
         json data = R"({"room_id" : "!sefiuhWgwghwWgh:example.com"})"_json;


### PR DESCRIPTION
As in MSC3231: https://github.com/matrix-org/matrix-doc/pull/3231

Seems a bit much just to get a boolean, but that's how it's done for all the other endpoints?

Proof it works: https://github.com/govynnus/nheko/blob/9fda611e060323384bc0ddf6bb011687e99a1315/src/RegisterPage.cpp#L496-L509