### PR TITLE
Actually read out rule_id in PushRule's from_json

### DIFF
--- a/lib/structs/pushrules.cpp
+++ b/lib/structs/pushrules.cpp
@@ -98,6 +98,7 @@ to_json(nlohmann::json &obj, const PushRule &rule)
 void
 from_json(const nlohmann::json &obj, PushRule &rule)
 {
+    rule.rule_id  = obj.value("rule_id", "");
     rule.default_ = obj.value("default", false);
     rule.enabled  = obj.value("enabled", true);
 

--- a/tests/pushrules.cpp
+++ b/tests/pushrules.cpp
@@ -33,7 +33,6 @@ TEST(Pushrules, GlobalRuleset)
           }
         ],
         "default": true,
-        "enabled": true,
         "pattern": "alice",
         "rule_id": ".m.rule.contains_user_name"
       }
@@ -43,7 +42,6 @@ TEST(Pushrules, GlobalRuleset)
         "actions": [
           "dont_notify"
         ],
-        "conditions": [],
         "default": true,
         "enabled": false,
         "rule_id": ".m.rule.master"
@@ -60,7 +58,6 @@ TEST(Pushrules, GlobalRuleset)
           }
         ],
         "default": true,
-        "enabled": true,
         "rule_id": ".m.rule.suppress_notices"
       }
     ],
@@ -87,7 +84,6 @@ TEST(Pushrules, GlobalRuleset)
           }
         ],
         "default": true,
-        "enabled": true,
         "rule_id": ".m.rule.call"
       },
       {
@@ -107,7 +103,6 @@ TEST(Pushrules, GlobalRuleset)
           }
         ],
         "default": true,
-        "enabled": true,
         "rule_id": ".m.rule.contains_display_name"
       },
       {
@@ -134,7 +129,6 @@ TEST(Pushrules, GlobalRuleset)
           }
         ],
         "default": true,
-        "enabled": true,
         "rule_id": ".m.rule.room_one_to_one"
       },
       {
@@ -167,7 +161,6 @@ TEST(Pushrules, GlobalRuleset)
           }
         ],
         "default": true,
-        "enabled": true,
         "rule_id": ".m.rule.invite_for_me"
       },
       {
@@ -186,7 +179,6 @@ TEST(Pushrules, GlobalRuleset)
           }
         ],
         "default": true,
-        "enabled": true,
         "rule_id": ".m.rule.member_event"
       },
       {
@@ -205,7 +197,6 @@ TEST(Pushrules, GlobalRuleset)
           }
         ],
         "default": true,
-        "enabled": true,
         "rule_id": ".m.rule.message"
       }
     ]
@@ -228,6 +219,7 @@ TEST(Pushrules, GlobalRuleset)
     EXPECT_EQ(rules.global.underride.size(), 6);
     EXPECT_EQ(rules.global.underride[0].conditions.at(0).key, "type");
     EXPECT_EQ(rules.global.content[0].rule_id, ".m.rule.contains_user_name");
+    EXPECT_EQ(data, json(rules));
 }
 
 TEST(Pushrules, GetGlobalRuleset)

--- a/tests/pushrules.cpp
+++ b/tests/pushrules.cpp
@@ -227,6 +227,7 @@ TEST(Pushrules, GlobalRuleset)
     EXPECT_EQ(rules.global.sender.size(), 0);
     EXPECT_EQ(rules.global.underride.size(), 6);
     EXPECT_EQ(rules.global.underride[0].conditions.at(0).key, "type");
+    EXPECT_EQ(rules.global.content[0].rule_id, ".m.rule.contains_user_name");
 }
 
 TEST(Pushrules, GetGlobalRuleset)


### PR DESCRIPTION
Fixes missing parsing for rule_id. Generating was already implemented, looks like this was simply a forgotten line.