### PR TITLE
Use stable forms for registration tokens

### DIFF
--- a/include/mtx/responses/register.hpp
+++ b/include/mtx/responses/register.hpp
@@ -33,7 +33,7 @@ void
 from_json(const nlohmann::json &obj, Register &response);
 
 //! Response from the `GET
-//! /_matrix/client/unstable/org.matrix.msc3231/register/org.matrix.msc3231.login.registration_token/validity`
+//! /_matrix/client/v1/register/m.login.registration_token/validity`
 //! endpoint.
 struct RegistrationTokenValidity
 {

--- a/include/mtx/user_interactive.hpp
+++ b/include/mtx/user_interactive.hpp
@@ -41,7 +41,7 @@ constexpr std::string_view dummy = "m.login.dummy";
 //! Authentication by accepting a set of terms like a privacy policy.
 constexpr std::string_view terms = "m.login.terms"; // see MSC1692
 //! Authentication using a registration token. See MSC3231.
-constexpr std::string_view registration_token = "org.matrix.msc3231.login.registration_token";
+constexpr std::string_view registration_token = "m.login.registration_token";
 }
 
 //! A list of auth types

--- a/lib/http/client.cpp
+++ b/lib/http/client.cpp
@@ -981,8 +981,7 @@ void
 Client::registration_token_validity(const std::string token,
                                     Callback<mtx::responses::RegistrationTokenValidity> cb)
 {
-    const auto api_path = "/client/unstable/org.matrix.msc3231/register/"
-                          "org.matrix.msc3231.login.registration_token/validity?" +
+    const auto api_path = "/client/v1/register/m.login.registration_token/validity?" +
                           mtx::client::utils::query_params({{"token", token}});
 
     get<mtx::responses::RegistrationTokenValidity>(

--- a/tests/requests.cpp
+++ b/tests/requests.cpp
@@ -272,7 +272,7 @@ TEST(Requests, UserInteractiveAuth)
 
     a.content = auth::RegistrationToken{"<token>"};
     EXPECT_EQ(nlohmann::json(a), R"({
-  "type": "org.matrix.msc3231.login.registration_token",
+  "type": "m.login.registration_token",
   "token": "<token>",
   "session": "<session ID>"
 })"_json);


### PR DESCRIPTION
https://spec.matrix.org/v1.2/client-server-api/#token-authenticated-registration

This isn't ready to be used yet because the patch for synapse hasn't been
merged (https://github.com/matrix-org/synapse/pull/11867).

Also I don't know how you're dealing with the new spec versioning so maybe this is annoying.