### PR TITLE
add default_payload to PusherData struct

### DIFF
--- a/include/mtx/requests.hpp
+++ b/include/mtx/requests.hpp
@@ -8,11 +8,7 @@
 
 #include <mtx/common.hpp>
 #include <mtx/events/collections.hpp>
-#if __has_include(<nlohmann/json_fwd.hpp>)
-#include <nlohmann/json_fwd.hpp>
-#else
 #include <nlohmann/json.hpp>
-#endif
 
 namespace mtx {
 //! Namespace for request structs
@@ -406,6 +402,8 @@ struct PusherData
     //! defined in the Push Gateway Specification. Currently the only format available is
     //! 'event_id_only'.
     std::string format;
+    //! Push gateway specific data.
+    std::optional<nlohmann::json> default_payload;
 
     friend void to_json(nlohmann::json &obj, const PusherData &data);
 };

--- a/lib/structs/requests.cpp
+++ b/lib/structs/requests.cpp
@@ -269,6 +269,9 @@ to_json(json &obj, const PusherData &data)
     if (!data.format.empty()) {
         obj["format"] = data.format;
     }
+    if (data.default_payload) {
+        obj["default_payload"] = data.default_payload.value();
+    }
 }
 
 void


### PR DESCRIPTION
followup from #100  the `default_payload` parameter added as an optional parameter to the `PusherData` data structure. 