### PR TITLE
URL preview support

### DIFF
--- a/include/mtx/responses/media.hpp
+++ b/include/mtx/responses/media.hpp
@@ -9,6 +9,7 @@
 #include <nlohmann/json.hpp>
 #endif
 
+#include <optional>
 #include <string>
 
 namespace mtx {
@@ -21,6 +22,43 @@ struct ContentURI
     std::string content_uri;
 
     friend void from_json(const nlohmann::json &obj, ContentURI &response);
+};
+
+// The json response is returned as prefixed fields (e.g. og:image:alt), not objects, so from_json
+// would be impractical
+//! Represents an OpenGraph og:image
+struct OGImage
+{
+    //! MIME type of the media
+    std::optional<std::string> type;
+    //! The number of pixels wide
+    std::optional<std::int32_t> width;
+    //! The number of pixels high
+    std::optional<std::int32_t> height;
+    //! A description of the media
+    std::optional<std::string> alt;
+    //! mxc:// URI of the media
+    std::string url;
+    //! Byte size of the og:image
+    std::uint64_t size;
+};
+
+//! Represents the response of `GET /_matrix/media/v3/preview_url`, see https://ogp.me
+struct URLPreview
+{
+    //! og:title
+    std::string title;
+    //! og:url
+    std::string url;
+    //! Structure containing og:image and related fields
+    OGImage image;
+
+    //! og:description
+    std::optional<std::string> description;
+    //! og:site_name
+    std::optional<std::string> site_name;
+
+    friend void from_json(const nlohmann::json &obj, URLPreview &response);
 };
 }
 }

--- a/include/mtxclient/http/client.hpp
+++ b/include/mtxclient/http/client.hpp
@@ -55,6 +55,7 @@ struct Available;
 struct AvatarUrl;
 struct ClaimKeys;
 struct ContentURI;
+struct URLPreview;
 struct CreateRoom;
 struct Device;
 struct EventId;
@@ -490,6 +491,9 @@ public:
                                      const std::string &content_type,
                                      const std::string &original_filename,
                                      RequestErr err)> cb);
+    void preview_url(const std::optional<std::int64_t> &timestamp,
+                     const std::string &url,
+                     Callback<mtx::responses::URLPreview> cb);
     std::string mxc_to_download_url(const std::string &mxc_url);
 
     //! Retrieve a thumbnail from the given mxc url.

--- a/lib/http/client.cpp
+++ b/lib/http/client.cpp
@@ -729,6 +729,27 @@ Client::download(const std::string &mxc_url,
 }
 
 void
+Client::preview_url(const std::optional<std::int64_t> &timestamp,
+                    const std::string &url,
+                    Callback<mtx::responses::URLPreview> callback)
+{
+    std::map<std::string, std::string> params;
+
+    if (timestamp) {
+        params.emplace("ts", std::to_string(*timestamp));
+    }
+
+    params.emplace("url", url);
+
+    const auto api_path = "/media/v3/preview_url?" + client::utils::query_params(params);
+    get<mtx::responses::URLPreview>(
+      api_path,
+      [callback = std::move(callback)](const mtx::responses::URLPreview &res,
+                                       HeaderFields,
+                                       RequestErr err) { callback(res, err); });
+}
+
+void
 Client::get_thumbnail(const ThumbOpts &opts, Callback<std::string> callback, bool try_download)
 {
     std::map<std::string, std::string> params;

--- a/lib/structs/responses/media.cpp
+++ b/lib/structs/responses/media.cpp
@@ -1,6 +1,7 @@
 #include "mtx/responses/media.hpp"
 
 #include <nlohmann/json.hpp>
+#include <type_traits>
 
 using json = nlohmann::json;
 
@@ -11,6 +12,44 @@ void
 from_json(const json &obj, ContentURI &res)
 {
     res.content_uri = obj.at("content_uri").get<std::string>();
+}
+
+template<typename T>
+static void
+extractOptionalAttribute(const json &obj, const char *name, std::optional<T> &out)
+{
+    if (obj.contains(name)) {
+        const auto &field = obj.at(name);
+        // Matrix's OpenGraph proxying does not standardize numbers to be actual json numbers, they
+        // can be (and, at least on synapse, sometimes are) strings
+        if constexpr (std::is_same_v<T, std::int32_t>) {
+            if (field.type() == json::value_t::string) {
+                out = static_cast<T>(std::stol(field.get<std::string>()));
+                return;
+            }
+        }
+        out = field.get<T>();
+    }
+}
+
+void
+from_json(const json &obj, URLPreview &res)
+{
+    res.title = obj.at("og:title").get<std::string>();
+    res.url   = obj.at("og:url").get<std::string>();
+    extractOptionalAttribute(obj, "og:site_name", res.site_name);
+
+    extractOptionalAttribute(obj, "og:image:type", res.image.type);
+    extractOptionalAttribute(obj, "og:image:width", res.image.width);
+    extractOptionalAttribute(obj, "og:image:height", res.image.height);
+    extractOptionalAttribute(obj, "og:image:alt", res.image.alt);
+
+    res.image.size = obj.at("matrix:image:size").get<std::uint64_t>();
+    res.image.url  = obj.at("og:image").get<std::string>();
+
+    if (obj.contains("og:description")) {
+        res.description = obj.at("og:description").get<std::string>();
+    }
 }
 }
 }

--- a/lib/structs/responses/media.cpp
+++ b/lib/structs/responses/media.cpp
@@ -38,6 +38,7 @@ from_json(const json &obj, URLPreview &res)
     res.title = obj.at("og:title").get<std::string>();
     res.url   = obj.at("og:url").get<std::string>();
     extractOptionalAttribute(obj, "og:site_name", res.site_name);
+    extractOptionalAttribute(obj, "og:description", res.description);
 
     extractOptionalAttribute(obj, "og:image:type", res.image.type);
     extractOptionalAttribute(obj, "og:image:width", res.image.width);
@@ -46,10 +47,6 @@ from_json(const json &obj, URLPreview &res)
 
     res.image.size = obj.at("matrix:image:size").get<std::uint64_t>();
     res.image.url  = obj.at("og:image").get<std::string>();
-
-    if (obj.contains("og:description")) {
-        res.description = obj.at("og:description").get<std::string>();
-    }
 }
 }
 }

--- a/tests/responses.cpp
+++ b/tests/responses.cpp
@@ -1721,3 +1721,48 @@ TEST(Response, Users)
     EXPECT_EQ(users.results[0].user_id, "@foo:bar.com");
     EXPECT_EQ(users.limited, false);
 }
+
+TEST(Response, PreviewURL)
+{
+    // Tests with both actual numbers and strings containing them, as both may be returned
+    json fullData = R"({
+          "og:title": "Example",
+          "og:url": "https://example.org",
+          "og:image:type": "image/png",
+          "og:image:width": 12345,
+          "og:image:height": 12345,
+          "og:image:alt": "Alt text",
+          "og:image": "mxc://example.org/abc",
+          "matrix:image:size": 12345,
+          "og:description": "Description",
+          "og:site_name": "example.org"
+        })"_json;
+
+    URLPreview full = fullData.get<URLPreview>();
+    ASSERT_EQ(full.title, "Example");
+    ASSERT_EQ(full.url, "https://example.org");
+    ASSERT_EQ(full.image.type, "image/png");
+    ASSERT_EQ(full.image.width, 12345);
+    ASSERT_EQ(full.image.height, 12345);
+    ASSERT_EQ(full.image.alt, "Alt text");
+    ASSERT_EQ(full.image.url, "mxc://example.org/abc");
+    ASSERT_EQ(full.image.size, 12345);
+    ASSERT_TRUE(full.site_name);
+    ASSERT_TRUE(full.description);
+    ASSERT_EQ(*full.description, "Description");
+    ASSERT_EQ(*full.site_name, "example.org");
+
+    json minData   = R"({
+          "og:title": "Example",
+          "og:url": "https://example.org",
+          "og:image": "mxc://example.org/abc",
+          "matrix:image:size": 12345
+        })"_json;
+    URLPreview min = minData.get<URLPreview>();
+    ASSERT_EQ(min.title, "Example");
+    ASSERT_EQ(min.url, "https://example.org");
+    ASSERT_EQ(min.image.url, "mxc://example.org/abc");
+    ASSERT_EQ(min.image.size, 12345);
+    ASSERT_FALSE(min.site_name);
+    ASSERT_FALSE(min.description);
+}


### PR DESCRIPTION
One thing to note is that not all optional OpenGraph fields are supported, only the ones that seem most useful for URL previews. Non-image media is unsupported as those are not proxied in the matrix API.
If/when this is accepted, I will work on https://github.com/Nheko-Reborn/nheko/issues/561.